### PR TITLE
fix: also return the headers when streaming [sc-50735]

### DIFF
--- a/lib/openai/sse_stream_parser.ex
+++ b/lib/openai/sse_stream_parser.ex
@@ -34,6 +34,9 @@ defmodule OpenAI.SSEStreamParser do
         {code, chunk}, acc when is_integer(code) ->
           {[], acc <> chunk}
 
+        {:header, chunk}, acc ->
+          {[chunk], acc}
+
         {:error, error}, acc ->
           {[error], acc}
       end,

--- a/lib/openai/stream.ex
+++ b/lib/openai/stream.ex
@@ -32,9 +32,9 @@ defmodule OpenAI.Stream do
             # We should be able to tell the difference between an error and the
             # event stream with content-type (text/event-stream), but
             # unfortunately OpenAI doesn't obey the spec.
-            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers} ->
+            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers} = header ->
               HTTPoison.stream_next(res)
-              {[], {code, res}}
+              {[{:header, header}], {code, res}}
 
             %HTTPoison.AsyncChunk{chunk: chunk} ->
               HTTPoison.stream_next(res)


### PR DESCRIPTION
To get information about the request, such as rate limiting, we put the AsyncHeader as the first message onto the stream.