### PR TITLE
chore: unify responses from client

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -43,10 +43,10 @@ defmodule OpenAI.Client do
 
       # html error responses
       {:ok, %HTTPoison.Response{status_code: status_code, body: body, headers: headers}} ->
-        {:error, %{status_code: status_code, body: body, headers: headers}}
+        {:error, %{status_code: status_code, body: body}, headers}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, reason}
+        {:error, reason, nil}
     end
   end
 


### PR DESCRIPTION
Change handle_response to always return a tuple of 3 and `nil` for the header if there is none.